### PR TITLE
[tuw_aruco] specifying range is not valid for string parameters

### DIFF
--- a/tuw_aruco/cfg/ArUco.cfg
+++ b/tuw_aruco/cfg/ArUco.cfg
@@ -23,7 +23,7 @@ marker_directory_enum = gen.enum([
     gen.const("TAG36h10", str_t, "TAG36h10", "")
 ], "Marker dictonary type")  
 
-gen.add("marker_dictonary", str_t, 0, "Marker dictonary type", "ARTOOLKITPLUSBCH", "ARUCO", "TAG36h10", edit_method=marker_directory_enum)
+gen.add("marker_dictonary", str_t, 0, "Marker dictonary type", "ARTOOLKITPLUSBCH", edit_method=marker_directory_enum)
 gen.add("marker_size", double_t, 0, "Marker size in meters", 0.06)
 gen.add("publish_tf", bool_t, 0, "", True)
 gen.add("publish_markers", bool_t, 0, "", True)


### PR DESCRIPTION
It seems that this compiles due to a [faulty check in dynamic_reconfigure](https://github.com/ros/dynamic_reconfigure/pull/122).

As specifying a range for a string parameter doesn't have much semantic value, this PR removed the range so that this package still compiles once https://github.com/ros/dynamic_reconfigure/pull/122 is merged and released